### PR TITLE
Set environemnt variables not only in the production build.

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -55,19 +55,23 @@ const getStyleLoadersFor = function (environment) {
   }
 };
 
+const getEnvironmentVariables = function () {
+  return {
+    'process.env.NODE_ENV': 'production',
+    'process.env.API_HOST': processenv('API_HOST') && JSON.stringify(processenv('API_HOST')),
+    'process.env.API_PORT': processenv('API_PORT'),
+    'process.env.STORAGE_HOST': processenv('STORAGE_HOST') && JSON.stringify(processenv('STORAGE_HOST')),
+    'process.env.STORAGE_PORT': processenv('STORAGE_PORT'),
+    'process.env.AUTH_IDENTITY_PROVIDER_URL': processenv('AUTH_IDENTITY_PROVIDER_URL') && JSON.stringify(processenv('AUTH_IDENTITY_PROVIDER_URL')),
+    'process.env.AUTH_CLIENT_ID': processenv('AUTH_CLIENT_ID') && JSON.stringify(processenv('AUTH_CLIENT_ID'))
+  };
+};
+
 const getPluginsFor = function (environment) {
   switch (environment) {
     case 'production':
       return [
-        new webpack.DefinePlugin({
-          'process.env.NODE_ENV': JSON.stringify('production'),
-          'process.env.API_HOST': processenv('API_HOST') && JSON.stringify(processenv('API_HOST')),
-          'process.env.API_PORT': processenv('API_PORT'),
-          'process.env.STORAGE_HOST': processenv('STORAGE_HOST') && JSON.stringify(processenv('STORAGE_HOST')),
-          'process.env.STORAGE_PORT': processenv('STORAGE_PORT'),
-          'process.env.AUTH_IDENTITY_PROVIDER_URL': processenv('AUTH_IDENTITY_PROVIDER_URL') && JSON.stringify(processenv('AUTH_IDENTITY_PROVIDER_URL')),
-          'process.env.AUTH_CLIENT_ID': processenv('AUTH_CLIENT_ID') && JSON.stringify(processenv('AUTH_CLIENT_ID'))
-        }),
+        new webpack.DefinePlugin(getEnvironmentVariables()),
         new CompressionPlugin({
           asset: '[path].gz[query]',
           algorithm: 'gzip',
@@ -86,6 +90,7 @@ const getPluginsFor = function (environment) {
       ];
     default:
       return [
+        new webpack.DefinePlugin(getEnvironmentVariables()),
         new webpack.HotModuleReplacementPlugin(),
         new HtmlWebpackPlugin({
           template: path.join(paths.src, 'template.ejs')

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -57,7 +57,7 @@ const getStyleLoadersFor = function (environment) {
 
 const getEnvironmentVariables = function () {
   return {
-    'process.env.NODE_ENV': 'production',
+    'process.env.NODE_ENV': JSON.stringify('production'),
     'process.env.API_HOST': processenv('API_HOST') && JSON.stringify(processenv('API_HOST')),
     'process.env.API_PORT': processenv('API_PORT'),
     'process.env.STORAGE_HOST': processenv('STORAGE_HOST') && JSON.stringify(processenv('STORAGE_HOST')),

--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
     {
       "name": "Matthias Wagler",
       "email": "matthias.wagler@thenativeweb.io"
+    },
+    {
+      "name": "René Viering",
+      "email": "rene.viering@gmail.com"
     }
   ],
   "wolkenkit": {


### PR DESCRIPTION
Hey,

thanks for the nice wolkenkit demo app :-)

While installing it with the help of your documentation, I stumbled about a problem with the environment variables. 

```
$ AUTH_IDENTITY_PROVIDER_URL=https://<username>.eu.auth0.com/authorize AUTH_CLIENT_ID=<clientid> bot serve
```

After executing this command the application started but without redirecting me to the correct identity provider defined inside  `AUTH_IDENTITY_PROVIDER_URL`. 

The problem is that environment variables are set in the `webpack.config.js` only for production. That's not the case with `bot serve`.  With my changes, the environment variables are now always set. Furthermore, `NODE_ENV` is currently always set to 'production'. If this is a problem, we have to think about a default value for `environment` inside of  `getPluginsFor`, it is `undefined` when calling `bot serve`.

Looking forward to your feedback.

René

