### PR TITLE
Add installation instructions for roboter-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ $ cd ./client
 $ npm install
 ```
 
+As roboter is used for build automation it is recommended to install roboter-cli globally. This way you can easily run roboter by simply typing bot. To install roboter-cli, run the following command.
+
+```shell
+$ npm install -g roboter-cli
+```
+
 Then, run `bot` and set the environment variables `AUTH_IDENTITY_PROVIDER_URL` and `AUTH_CLIENT_ID` accordingly:
 
 ```shell


### PR DESCRIPTION
Hey,

I've noticed that there were no installation instructions for `roboter-cli`. I added some lines in the section "Running the frontend". I think it helps to get a better installation experience by following the documentation.

René